### PR TITLE
Remove extra print command in ramp_optimize

### DIFF
--- a/pynrc_core.py
+++ b/pynrc_core.py
@@ -1588,7 +1588,7 @@ class NIRCam(object):
 						nint_all = nint_all[i1:i2]
 						
 					
-					print(len(nint_all))
+					#print(len(nint_all))
 					for nint in nint_all:
 						if nint > nint_max:
 							break


### PR DESCRIPTION
I commented out an extra print command in the NIRCam.ramp_optimize() method.