### PR TITLE
Tweaked call to find_packages to find them all

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     #packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    packages=find_packages(include=['pynrc']),
+    packages=find_packages(include=['pynrc*']),
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's


### PR DESCRIPTION
The `packages=find_packages(include=['pynrc'])` call only returns `pynrc` for me. However, with a wildcard it will correctly find `maths`, `reduce` etc. to properly install them.
