### PR TITLE
Fixed missing kwargs that causes errors

### DIFF
--- a/pynrc/pynrc_core.py
+++ b/pynrc/pynrc_core.py
@@ -1567,7 +1567,7 @@ class NIRCam(object):
 
         return fzodi_pix
         
-    def saturation_levels(self, sp, full_size=True, ngroup=2, **kwargs):
+    def saturation_levels(self, sp, image = None, full_size=True, ngroup=2, **kwargs):
         """Saturation levels.
         
         Create image showing level of saturation for each pixel.


### PR DESCRIPTION
Line 1615: "if image is not None:" causes error that says "Image is not defined" because it was not included as a keyword, which the conditional statement implies that it should be.